### PR TITLE
Upgrade Nanoc to 4.10.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-gem "nanoc", "~> 4.9"
+gem "nanoc", "~> 4.10"
 gem "adsf"
 gem "adsf-live"
 gem "haml"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
     coderay (1.1.2)
     colored (1.2)
     concurrent-ruby (1.0.5)
-    cri (2.15.1)
+    cri (2.15.2)
       colored (~> 1.2)
     ddmemoize (1.0.0)
       ddmetrics (~> 1.0)
@@ -47,6 +47,7 @@ GEM
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
     http_parser.rb (0.6.0)
+    json_schema (0.19.1)
     kramdown (1.17.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -54,13 +55,14 @@ GEM
       ruby_dep (~> 1.2)
     lumberjack (1.0.13)
     method_source (0.9.0)
-    nanoc (4.9.6)
+    nanoc (4.10.2)
       addressable (~> 2.5)
       cri (~> 2.15)
       ddmemoize (~> 1.0)
       ddmetrics (~> 1.0)
       ddplugin (~> 1.0)
       hamster (~> 3.0)
+      json_schema (~> 0.19)
       parallel (~> 1.12)
       ref (~> 2.0)
       slow_enumerator_tools (~> 1.0)
@@ -104,8 +106,8 @@ DEPENDENCIES
   guard-nanoc
   haml
   kramdown
-  nanoc (~> 4.9)
+  nanoc (~> 4.10)
   sass
 
 BUNDLED WITH
-   1.16.1
+   1.16.6


### PR DESCRIPTION
CC @moll — this contains a fix for nanoc/nanoc#1372.